### PR TITLE
Update to nodejs 0.12 and remove dependency on execSync

### DIFF
--- a/classifiers/multilabel/Adaboost.js
+++ b/classifiers/multilabel/Adaboost.js
@@ -3,9 +3,8 @@ var sprintf = require("sprintf").sprintf;
 var _ = require("underscore")._;
 var fs = require('fs');
 var partitions = require('../../utils/partitions');
-var execSync = require('execSync')
 var crypto = require('crypto')
-var execSync = require('execSync').exec
+var child_process = require('child_process');
 
 /**
  * Adaptive Boosting (Adaboost) is a greedy search for a linear combination of 
@@ -39,9 +38,13 @@ var Adaboost = function(opts) {
 }
 
 Adaboost.isInstalled = function() {
-	var result = execSync("./icsiboost");
-	return (result.code!=127);
-}
+  try {
+    var result = child_process.execSync("./icsiboost");
+    return true;
+  } catch (e) {
+    return (e.status != 127);
+  }
+};
 
 Adaboost.prototype = {
 
@@ -97,7 +100,7 @@ Adaboost.prototype = {
 			fs.writeFileSync("./"+this.folder+"/"+this.assigner+"."+key1, str)
 		}, this)
 
-		var result = execSync("./icsiboost -S ./"+this.folder+"/"+this.assigner+" -n "+this.iterations)
+		var result = child_process.execSync("./icsiboost -S ./"+this.folder+"/"+this.assigner+" -n "+this.iterations)
 		console.log(result)
 	},
 
@@ -107,7 +110,7 @@ Adaboost.prototype = {
 
 		fs.writeFileSync("./"+this.folder+"/"+this.assigner+".test", sample.replace(/\,/g,'')+"\n")
 		fs.writeFileSync("./"+this.folder+"/"+this.assigner+".test", sample+"\n")
-		var result = execSync("./icsiboost -S ./"+this.folder+"/"+this.assigner +" -W "+this.ngram_length+" -N "+this.text_expert+" -C < ./"+this.folder+"/"+this.assigner+".test > ./"+this.folder+"/"+this.assigner+".output")
+		var result = child_process.execSync("./icsiboost -S ./"+this.folder+"/"+this.assigner +" -W "+this.ngram_length+" -N "+this.text_expert+" -C < ./"+this.folder+"/"+this.assigner+".test > ./"+this.folder+"/"+this.assigner+".output")
 		var stats = fs.readFileSync("./"+this.folder+"/"+this.assigner+".output", "utf8");
 
 		set_of_labels = this.set_of_labels

--- a/classifiers/svm/SvmLinear.js
+++ b/classifiers/svm/SvmLinear.js
@@ -30,12 +30,16 @@ function SvmLinear(opts) {
 }
 
 SvmLinear.isInstalled = function() {
-	var result = execSync("liblinear_train");
-	return (result.code!=127);
-}
+  try {
+    var result = child_process.execSync("liblinear_train");
+    return true;
+  } catch (e) {
+    return (e.status != 127);
+  }
+};
 
 var util  = require('util')
-  , execSync = require('execSync').exec
+  , child_process = require('child_process')
   , exec = require('child_process').exec
   , fs   = require('fs')
   , svmcommon = require('./svmcommon')
@@ -69,7 +73,7 @@ SvmLinear.prototype = {
 			var command = "liblinear_train "+this.learn_args+" "+learnFile + " "+modelFile;
 			if (this.debug) console.log("running "+command);
 
-			var result = execSync(command);
+			var result = child_process.execSync(command);
 			if (result.code>0) {
 				console.dir(result);
 				console.log(fs.readFileSync(learnFile, 'utf-8'));

--- a/classifiers/svm/SvmPerf.js
+++ b/classifiers/svm/SvmPerf.js
@@ -17,7 +17,7 @@
 
 var fs   = require('fs')
   , util  = require('util')
-  , execSync = require('execSync').exec
+  , child_process = require('child_process')
   , exec = require('child_process').exec
   , svmcommon = require('./svmcommon')	
   , _ = require("underscore")._;
@@ -38,9 +38,13 @@ function SvmPerf(opts) {
 }
 
 SvmPerf.isInstalled = function() {
-	var result = execSync("svm_perf_learn -c 1 a");
-	return (result.code!=127);
-}
+  try {
+    var result = child_process.execSync("svm_perf_learn -c 1 a");
+    return true;
+  } catch (e) {
+    return (e.status != 127);
+  }
+};
 
 var FIRST_FEATURE_NUMBER=1;  // in svm perf, feature numbers start with 1, not 0!
 
@@ -62,7 +66,7 @@ SvmPerf.prototype = {
 			var command = "svm_perf_learn "+this.learn_args+" "+learnFile + " "+modelFile;
 			if (this.debug) console.log("running "+command);
 	
-			var result = execSync(command);
+			var result = child_process.execSync(command);
 			if (result.code>0) {
 				console.dir(result);
 				console.log(fs.readFileSync(learnFile, 'utf-8'));

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
     "url": "https://github.com/erelsgl/limdu.git"
   },
   "dependencies": {
-    "underscore": "*",
+    "brain": "*",
+    "graph-paths": "latest",
+    "languagemodel": "latest",
+    "natural": "^0.2.0",
     "sprintf": "*",
     "svm": "*",
     "temp": "*",
-    "wordsworth": "*",
-    "execSync": "*",
-    "brain": "*",
-    "graph-paths": "latest",
-    "languagemodel": "latest"
+    "underscore": "*",
+    "wordsworth": "*"
   },
   "devDependencies": {
     "mocha": ">=1.0.0",
@@ -26,15 +26,15 @@
     "test": "mocha"
   },
   "contributors": [
-                   {
-                     "name": "Erel Segal-Halevi",
-                     "email": "erelsgl@gmail.com"
-                   },
-                   {
-                       "name": "Vasily Konovalov",
-                       "email": "vasili.konov@gmail.com"
-                   }
-  ],   	
+    {
+      "name": "Erel Segal-Halevi",
+      "email": "erelsgl@gmail.com"
+    },
+    {
+      "name": "Vasily Konovalov",
+      "email": "vasili.konov@gmail.com"
+    }
+  ],
   "keywords": [
     "classifier",
     "classification",

--- a/test/classifiersTest/kNNTest.js
+++ b/test/classifiersTest/kNNTest.js
@@ -38,7 +38,7 @@ var kNNClassifier = classifiers.kNN.bind(this, {
 var kNNClassifier2 = classifiers.kNN.bind(this, {
     k: 1,
 	distanceFunction: 'EuclideanDistance',
-	distanceWeightening: weightInstance
+	distanceWeightening: weightInstance1
 });
 
 var kNNClassifierE = classifiers.EnhancedClassifier.bind(this, {

--- a/utils/unseen_correlation.js
+++ b/utils/unseen_correlation.js
@@ -11,7 +11,6 @@
 
 var _ = require('underscore')._;
 var fs = require('fs');
-var execSync = require('execSync')
 var partitions = require('./partitions');
 var trainAndTest = require('./trainAndTest').trainAndTest;
 var trainAndTest_hash= require('./trainAndTest').trainAndTest_hash;

--- a/utils/unseen_curves.js
+++ b/utils/unseen_curves.js
@@ -15,7 +15,7 @@
 
 var _ = require('underscore')._;
 var fs = require('fs');
-var execSync = require('execSync')
+var child_process = require('child_process')
 var partitions = require('./partitions');
 var trainAndTest = require('./trainAndTest').trainAndTest;
 var natural = require('natural');
@@ -69,11 +69,11 @@ module.exports.unseen_word_curves = function(dataset) {
 		{
 			console.log("The existing report is found. If you want to draw a learning curves, remove the existing report")
 			command = "gnuplot -p -e \"plot \'"+dir+"unseen_curves\' using 1:2 with lines\""
-			result = execSync.run(command)
+			result = child_process.execSync(command)
 	    	return 0
 		}
 
-	var result = execSync.run("gnuplot -V");
+	var result = child_process.execSync("gnuplot -V");
 	if (result !=0 ) {
 		console.log("gnuplot is not found")
 		return 0


### PR DESCRIPTION
This removes the dependency on the deprecated execSync and make limdu work with node 0.12.