### PR TITLE
removing `natural` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,13 @@
     "type": "git",
     "url": "https://github.com/erelsgl/limdu.git"
   },
-  "engines" : { 
-	  "node" : ">=0.12" 
+  "engines" : {
+	  "node" : ">=0.12"
   },
   "dependencies": {
     "brain": "*",
     "graph-paths": "latest",
     "languagemodel": "latest",
-    "natural": "^0.2.0",
     "sprintf": "*",
     "svm": "*",
     "temp": "*",


### PR DESCRIPTION
It looks like natural was removed everywhere but `package.json`.  I've removed it from there, ran the tests and it looks like they passed. 

I did get this but I'm not sure if that normally happens.
```
/bin/sh: liblinear_train: command not found
liblinear_train not found - SvmMulticlass tests skipped.
/bin/sh: svm_perf_learn: command not found
svm_perf_learn not found - SvmPerf tests skipped.
/bin/sh: liblinear_train: command not found
liblinear_train not found - SvmLinear tests skipped.
/bin/sh: ./icsiboost: No such file or directory
icsiboost not found - Adaboost tests skipped.
/bin/sh: svm_perf_learn: command not found
svm_perf_learn not found - MetaLabelerSvmPerf tests skipped.
/bin/sh: liblinear_train: command not found
liblinear_train not found - MetaLabelerSvmLinear tests skipped.
```